### PR TITLE
add missing header & footer markup from cherry-pick

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -11,7 +11,8 @@
 
   %body
     = render 'layouts/partials/header'
-    = flash.each do |key, value|
-      = value
+    - if flash.any?
+      = flash.each do |key, value|
+        = value
     = yield
     = render 'layouts/partials/footer'

--- a/app/views/layouts/partials/_header.html.haml
+++ b/app/views/layouts/partials/_header.html.haml
@@ -1,10 +1,13 @@
-%header
-  %nav
-    %h1 Slow Food Online
-    %ul.inline-list
+.top-bar
+  .top-bar-left
+    %ul.menu
+      %li.menu-text
+        = link_to 'Slow Food Online', root_path
+  .top-bar-right
+    %ul.menu
       %li
-        %a{href: "#{}"} Home
+        = link_to 'Home', root_path
       %li
-        = link_to 'Login'
+        = link_to 'Login', new_user_session_path
       %li
-        %a{href: "#{}"} Sign Up
+        = link_to 'Sign Up', new_user_registration_path


### PR DESCRIPTION
PT Story: No story

Changes proposed in this pull request:
I missed some stuff when cherry-picking @lollypop27 commits so I'm just adding them back :(

What I have learned working on this feature:
Carefully check stuff while cherry-picking to make sure you aren't losing any piece of code 😏 

Screenshots:

`Header`
![screenshot 2016-08-25 15 37 00](https://cloud.githubusercontent.com/assets/4028374/17971163/e717a6a6-6ad9-11e6-8df1-1679f19a636f.png)

`Footer`
![screenshot 2016-08-25 15 37 09](https://cloud.githubusercontent.com/assets/4028374/17971164/e72110a6-6ad9-11e6-8b3e-cc63f42363a7.png)

@MikaelFeher Ready for review!
