### PR TITLE
Fixes the funky looking double messages in brackets

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -13,7 +13,7 @@
     = javascript_include_tag 'application', 'data-turbolinks-track' => 'reload'
     = render 'layouts/partials/header'
     - if flash.any?
-      = flash.each do |key, value|
+      - flash.each do |key, value|
         = value
     .wrapper.row
       = yield


### PR DESCRIPTION
PT Story: https://www.pivotaltracker.com/story/show/129055865

Changes proposed in this pull request:
- Fixes the funky looking double messages in brackets

What I have learned working on this feature:
- How important it i to make sure that ruby injections have `-` and  `=` in the correct places.

Screenshots:
Before:
![screen shot 2016-08-28 at 19 36 00 2](https://cloud.githubusercontent.com/assets/18580001/18035469/dc7211da-6d56-11e6-8a56-6bed305e0cb0.png)

After:
![screen shot 2016-08-28 at 19 36 19 2](https://cloud.githubusercontent.com/assets/18580001/18035481/f6527dce-6d56-11e6-9942-3b1f74cdfc5e.png)

Ready for review!
